### PR TITLE
List subcommand

### DIFF
--- a/lib/chef/knife/helper_list.rb
+++ b/lib/chef/knife/helper_list.rb
@@ -1,0 +1,43 @@
+require 'chef'
+require 'knife/helper/commands'
+require 'knife/helper/config'
+
+class Chef
+  class Knife
+    class HelperList < Chef::Knife
+
+      banner "knife helper list REGEX (option)"
+
+      option :file,
+        :short => "-f FILE",
+        :long => "--file FILE",
+        :description => "Path to config file(yaml)",
+        :default => ""
+
+      def run
+        file = config[:file] == "" ? default_config_file : config[:file]
+        commands = ::Knife::Helper::Commands.new(
+          ::Knife::Helper::Config.new(file).data
+        )
+        unless @name_args.empty?
+          cm = commands.commands.select{|c| Regexp.new(@name_args.first).match(c['name']) }
+        else
+          cm = commands.commands
+        end
+        cm.map! do |c|
+          {
+            c['name'] => c['command']
+          }
+        end
+        output(format_for_display(cm))
+      end
+
+      private
+
+      def default_config_file
+        ::File.join(Dir.pwd, ".knife.helper.yml")
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/helper_list.rb
+++ b/lib/chef/knife/helper_list.rb
@@ -24,12 +24,11 @@ class Chef
         else
           cm = commands.commands
         end
+        hash = {}
         cm.map! do |c|
-          {
-            c['name'] => c['command']
-          }
+          hash[c['name']] = c['command']
         end
-        output(format_for_display(cm))
+        output(ui.presenter.format_for_display(hash))
       end
 
       private

--- a/lib/knife/helper/commands.rb
+++ b/lib/knife/helper/commands.rb
@@ -3,6 +3,8 @@ module Knife
   module Helper
     class Commands
 
+      attr_reader :commands
+
       def initialize(config)
         @base = config['settings']['command_base']
         @commands = config['commands']


### PR DESCRIPTION
#3 を実装してみました。

サンプルのyamlがこんな感じならば、

``` .knife.helper.yml

---
includes:

settings:
  command_base: /Users/sawanoboriyu/worktemp/knife-digital_ocean-zero_example/bin/knife

commands:
  - name: do_keys
    command: digital_ocean sshkey list
    condition:
    options:
  - name: do_sizes
    command: digital_ocean size list
    condition:
    options:
  - name: do_dls
    command: digital_ocean size list
    condition:
    options:
```

次のような感じで一覧を表示します。

```
$ knife helper list 
do_dls:   digital_ocean size list
do_keys:  digital_ocean sshkey list
do_sizes: digital_ocean size list
```

```
$ knife helper list -F json
{
  "do_keys": "digital_ocean sshkey list",
  "do_sizes": "digital_ocean size list",
  "do_dls": "digital_ocean size list"
}
```
