### PR TITLE
raise_if_none_zero_exit

### DIFF
--- a/lib/knife/helper/commands.rb
+++ b/lib/knife/helper/commands.rb
@@ -46,7 +46,7 @@ module Knife
       end
 
       def exec(name)
-        system(build(name))
+        raise "Helper exec finished with non-zero exit code" unless system(build(name))
       end
 
       def complete_option(opt)


### PR DESCRIPTION
exec の内容が失敗したらnilかfalseでそのまま進むので、raiseしておきたいです。
